### PR TITLE
THIRD-PARTY-NOTICES: Add author and fix name

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -2,7 +2,8 @@ Third-Party Notices
 
 This project incorporates components from the projects listed below. The original copyright notices and the licenses under which nitrotpm-attestation-samples received such components are set forth below.
 
-- teemanager (https://github.com/haraldh/teemanager)
+- teemager (https://github.com/haraldh/teemager)
   Copyright (c) 2003-2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
+  Author: Harald Hoyer
   License: MIT
   https://github.com/haraldh/teemager/blob/main/LICENSE


### PR DESCRIPTION
This project was partially inspired by code from Harald Hoyer. We already refer to that code in the third party notice file. To also give credits to the person in addition to the code, add the author's name.

While at it, fix a typo in the repository name.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
