### PR TITLE
Fix and update NitroTPM tools revision

### DIFF
--- a/nix/image/lib.nix
+++ b/nix/image/lib.nix
@@ -14,11 +14,10 @@ let
     pcr-compute = craneLib.buildPackage {
         cargoArtifacts = tee-pkgs.kms-decrypt-app.cargoArtifacts;
         pname = "nitro-tpm-pcr-compute";
-        version = "0.0.1";
+        version = "1.0.0";
         src = builtins.fetchGit {
-            url = "git@github.com:aws/NitroTPM-Tools.git";
-            rev = "eab69e7a4ebd0f6d5d41ff80882df6292d3e2b38";
-            ref = "main";
+            url = "https://github.com/aws/NitroTPM-Tools.git";
+            rev = "50f0fb58a306ee89c7994183cbce3bf4f3331207";
         };
         cargoExtraArgs = "--package nitro-tpm-pcr-compute";
         strictDeps = true;

--- a/nix/tee/packages.nix
+++ b/nix/tee/packages.nix
@@ -6,13 +6,13 @@
 let
     src = builtins.fetchGit {
         url = "https://github.com/aws/NitroTPM-Tools.git";
-        ref = "main";
+        rev = "50f0fb58a306ee89c7994183cbce3bf4f3331207";
     };
 
     cargoArtifacts = craneLib.buildDepsOnly {
         inherit src;
         pname = "nitro-tpm-tools";
-        version = "0.0.1";
+        version = "1.0.0";
         strictDeps = true;
         doCheck = false;
 
@@ -28,7 +28,7 @@ in {
     kms-decrypt-app = craneLib.buildPackage {
         inherit cargoArtifacts src;
         pname = "kms-decrypt-app";
-        version = "0.0.1";
+        version = "1.0.0";
 
         cargoExtraArgs = "--example nitro-tpm-kms-decrypt";
         strictDeps = true;


### PR DESCRIPTION
An earlier commit updating the NitroTPM tools repository removed the revision pinning which broke pure builds. This change pins both instances to the latest revision and standardizes on using HTTPS URLs. The unnecessary 'ref = main' parameter has been removed since we are using pinned revisions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
