### PR TITLE
Add secure boot support

### DIFF
--- a/nix/examples/nginx-kms/README.md
+++ b/nix/examples/nginx-kms/README.md
@@ -14,6 +14,14 @@ Before you begin, ensure you have the following:
 - Nix package manager installed
 - `jq` command-line JSON processor
 
+## Important Note on Secure Boot and Reproducibility
+
+When using secure boot enabled builds (e.g., `raw-image-secure-boot`), the builds are **NOT reproducible** because this example generates cryptographic keys at build time. Each build will produce different keys and therefore different measurements for PCR7.
+
+In production scenarios, you should use consistent key material across builds to maintain reproducible measurements.
+
+The non-secure-boot builds (`raw-image`) remain fully reproducible.
+
 ## Getting Started
 Follow these steps to set up and test the Attestable AMI:
 

--- a/nix/examples/nginx-kms/scripts/start.sh
+++ b/nix/examples/nginx-kms/scripts/start.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
 # Parse command line arguments
+SECURE_BOOT_FLAG=""
 DEBUG_FLAG=""
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --secure-boot)
+      SECURE_BOOT_FLAG="--secure-boot"
+      shift
+      ;;
     --debug)
       DEBUG_FLAG="--debug"
       shift
@@ -74,6 +79,11 @@ check_credentials_var() {
 
 echo "Starting deployment process..."
 
+# Display secure boot warning if secure boot mode is enabled
+if [ -n "$SECURE_BOOT_FLAG" ]; then
+  echo -e "\033[33m⚠️  WARNING: Secure boot builds are NOT reproducible (keys generated at build time)! ⚠️\033[0m"
+fi
+
 # Display debug warning if debug mode is enabled
 if [ -n "$DEBUG_FLAG" ]; then
   echo -e "\033[31m⚠️  WARNING: Building in DEBUG mode with operator access enabled! ⚠️\033[0m"
@@ -88,7 +98,7 @@ check_credentials_var AWS_DEFAULT_REGION
 echo "AWS credentials are set and validated."
 
 echo "Step 1: Creating AMI..."
-OUTPUT=$("$SCRIPT_DIR/steps/00_create_ami.sh" $DEBUG_FLAG)
+OUTPUT=$("$SCRIPT_DIR/steps/00_create_ami.sh" $SECURE_BOOT_FLAG $DEBUG_FLAG)
 
 if [ $? -ne 0 ]; then
   echo "Error: AMI creation failed"

--- a/nix/examples/nginx-kms/scripts/steps/00_create_ami.sh
+++ b/nix/examples/nginx-kms/scripts/steps/00_create_ami.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
 # Parse command line arguments
-PACKAGE_NAME="raw-image"
+SECURE_BOOT=false
+DEBUG=false
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --secure-boot)
+      SECURE_BOOT=true
+      shift
+      ;;
     --debug)
-      PACKAGE_NAME="raw-image-debug"
+      DEBUG=true
       shift
       ;;
     *)
@@ -15,7 +20,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Build the package name based on flags
+PACKAGE_NAME="raw-image"
+[ "$SECURE_BOOT" = true ] && PACKAGE_NAME="${PACKAGE_NAME}-secure-boot"
+[ "$DEBUG" = true ] && PACKAGE_NAME="${PACKAGE_NAME}-debug"
+
 echo "Running Nix UKI build for package: $PACKAGE_NAME"
+
 nix --extra-experimental-features nix-command --extra-experimental-features flakes build .#$PACKAGE_NAME
 
 if [ $? -ne 0 ]; then
@@ -31,7 +42,12 @@ if [ ! -d "result" ]; then
 fi
 
 echo "Creating UKI AMI..."
-nix --extra-experimental-features nix-command --extra-experimental-features flakes run .#create-ami -- result/nixos-tee_1.raw
+
+# Build the AMI creation target name
+CREATE_AMI_TARGET="create-ami"
+[ "$SECURE_BOOT" = true ] && CREATE_AMI_TARGET="${CREATE_AMI_TARGET}-secure-boot"
+
+nix --extra-experimental-features nix-command --extra-experimental-features flakes run .#$CREATE_AMI_TARGET -- result/nixos-tee_1.raw
 
 if [ $? -ne 0 ]; then
   echo "Error: UKI AMI creation failed"

--- a/nix/examples/nginx-kms/secure-boot-data.nix
+++ b/nix/examples/nginx-kms/secure-boot-data.nix
@@ -1,0 +1,75 @@
+{ pkgs, lib, stdenv }:
+
+# WARNING: This secure boot data generation is NOT reproducible!
+# Keys are generated at build time, resulting in different measurements for each build.
+# In production, use consistent pre-generated key material for reproducible builds.
+#
+# This module generates a complete secure boot key hierarchy and provides the db key and certificate for EFI binary signing:
+# - Platform Key (PK): Root of trust, signs KEK updates
+# - Key Exchange Key (KEK): Signs signature database updates
+# - Signature Database (db): Contains keys that can sign bootloaders/kernels
+
+let
+  python-uefivars = pkgs.fetchFromGitHub {
+    owner = "awslabs";
+    repo = "python-uefivars";
+    rev = "main";
+    sha256 = "sha256-HzaKFyKMqEADPvydCdD29P9nC7Qwq/UYvgZYCx4oEhw=";
+  };
+
+  pythonEnv = pkgs.python3.withPackages (ps: with ps; [
+    google-crc32c
+  ]);
+
+  secureBootKeys = pkgs.runCommand "secure-boot-keys" {
+    nativeBuildInputs = [
+      pkgs.openssl
+      pkgs.util-linux
+      pkgs.efitools
+    ];
+  } ''
+    mkdir -p $out
+
+    echo "INFO: Generate a GUID"
+    uuidgen --random > GUID.txt
+
+    echo "INFO: Create the platform key (PK)"
+    openssl req -newkey rsa:4096 -nodes -keyout PK.key -new -x509 -sha256 -days 3650 -subj "/CN=Platform key/" -out PK.crt
+    openssl x509 -outform DER -in PK.crt -out PK.cer
+    cert-to-efi-sig-list -g "$(< GUID.txt)" PK.crt PK.esl
+    sign-efi-sig-list -g "$(< GUID.txt)" -k PK.key -c PK.crt PK PK.esl PK.auth
+
+    echo "INFO: Create the key exchange key (KEK)"
+    openssl req -newkey rsa:4096 -nodes -keyout KEK.key -new -x509 -sha256 -days 3650 -subj "/CN=Key Exchange Key/" -out KEK.crt
+    openssl x509 -outform DER -in KEK.crt -out KEK.cer
+    cert-to-efi-sig-list -g "$(< GUID.txt)" KEK.crt KEK.esl
+    sign-efi-sig-list -g "$(< GUID.txt)" -k PK.key -c PK.crt KEK KEK.esl KEK.auth
+
+    echo "INFO: Create the signature database (db)"
+    openssl req -newkey rsa:4096 -nodes -keyout db.key -new -x509 -sha256 -days 3650 -subj "/CN=Signature Database key/" -out db.crt
+    openssl x509 -outform DER -in db.crt -out db.cer
+    cert-to-efi-sig-list -g "$(< GUID.txt)" db.crt db.esl
+    sign-efi-sig-list -g "$(< GUID.txt)" -k KEK.key -c KEK.crt db db.esl db.auth
+
+    cp db.key db.crt *.esl $out/
+  '';
+
+  uefiVarStore = pkgs.runCommand "uefi-var-store" {
+    nativeBuildInputs = [ pythonEnv ];
+  } ''
+    mkdir -p $out
+
+    python ${python-uefivars}/uefivars -i none -o aws -O "$out/uefi_data.aws" \
+        -P ${secureBootKeys}/PK.esl \
+        -K ${secureBootKeys}/KEK.esl \
+        --db ${secureBootKeys}/db.esl
+  '';
+
+in
+pkgs.runCommand "secure-boot-data" {} ''
+  mkdir -p $out
+
+  cp ${secureBootKeys}/db.key ${secureBootKeys}/db.crt ${secureBootKeys}/*.esl $out/
+'' // {
+  inherit uefiVarStore;
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -28,9 +28,9 @@
 
             lib = {
               # Lib function to build a raw TEE image
-              tee-image = { userConfig ? { }, isDebug ? false } :
+              tee-image = { userConfig ? { }, isDebug ? false, secureBootData ? null } :
                 pkgs.callPackage ./image/lib.nix {
-                  inherit craneLib nixos-generators userConfig isDebug;
+                  inherit craneLib nixos-generators userConfig isDebug secureBootData;
                   tee-pkgs = packages;
                 };
             };

--- a/nix/image/lib.nix
+++ b/nix/image/lib.nix
@@ -7,6 +7,7 @@
   tee-pkgs,
   userConfig ? { },
   isDebug ? false,
+  secureBootData ? null,
   ...
 }:
 let
@@ -30,6 +31,32 @@ let
             pkgs.tpm2-tss
         ];
     };
+
+    # Sign EFI binary with secure boot keys if secureBootData is provided
+    sign-efi = efiPath:
+        if secureBootData != null then
+            pkgs.runCommand "signed-efi" {
+                nativeBuildInputs = [ pkgs.sbsigntool ];
+            } ''
+                mkdir -p $out
+
+                # Verify required secure boot files exist
+                if [ ! -f "${secureBootData}/db.key" ]; then
+                    echo "ERROR: Secure boot signing key not found: ${secureBootData}/db.key"
+                    exit 1
+                fi
+                if [ ! -f "${secureBootData}/db.crt" ]; then
+                    echo "ERROR: Secure boot certificate not found: ${secureBootData}/db.crt"
+                    exit 1
+                fi
+
+                # Sign the EFI binary using the signature database (db) key
+                sbsign --key ${secureBootData}/db.key \
+                       --cert ${secureBootData}/db.crt \
+                       --output $out/signed.efi \
+                       ${efiPath}
+            ''
+        else null;
 
     tee-config = {
         environment = {
@@ -65,11 +92,33 @@ let
         customFormats = {"verity" = ./verity.nix;};
         format = "verity";
     }).overrideAttrs
-        (oldAttrs: {
-            # Compute PCR4 of TPM based on EFI file
-            postInstall = ''
-                efi_path=${oldAttrs.finalPartitions."00-esp".contents."/EFI/BOOT/${efiFileName}".source}
-                ${pcr-compute}/bin/nitro-tpm-pcr-compute --image $efi_path > $out/tpm_pcr.json
+        (oldAttrs: let
+            originalEfiPath = oldAttrs.finalPartitions."00-esp".contents."${ukiPath}".source;
+            signedEfiDrv = sign-efi originalEfiPath;
+            finalEfiPath = if signedEfiDrv != null then "${signedEfiDrv}/signed.efi" else originalEfiPath;
+        in {
+            finalPartitions = lib.recursiveUpdate oldAttrs.finalPartitions {
+                "00-esp".contents = {
+                    "${ukiPath}".source = finalEfiPath;
+                };
+            };
+
+            postInstall = let
+                # Build secure boot arguments for PCR7 computation
+                secureBootArgs = lib.optionals (secureBootData != null) (
+                    lib.optional (builtins.pathExists "${secureBootData}/PK.esl") "--PK ${secureBootData}/PK.esl" ++
+                    lib.optional (builtins.pathExists "${secureBootData}/KEK.esl") "--KEK ${secureBootData}/KEK.esl" ++
+                    lib.optional (builtins.pathExists "${secureBootData}/db.esl") "--db ${secureBootData}/db.esl" ++
+                    lib.optional (builtins.pathExists "${secureBootData}/dbx.esl") "--dbx ${secureBootData}/dbx.esl"
+                );
+            in ''
+                # Compute TPM PCR values including secure boot measurements
+                ${pcr-compute}/bin/nitro-tpm-pcr-compute --image ${finalEfiPath} ${lib.concatStringsSep " " secureBootArgs} > $out/tpm_pcr.json
+
+                ${lib.optionalString (secureBootData != null) ''
+                    # Verify the EFI binary signature for secure boot compliance
+                    ${pkgs.sbsigntool}/bin/sbverify --cert ${secureBootData}/db.crt "${finalEfiPath}"
+                ''}
             '';
         });
 in pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
This commit introduces secure boot capabilities to the image build flow and extends the nginx-kms example with an option to enable secure boot.

The implementation integrates EFI binary signing into the build process. When secure boot is enabled, the build system automatically signs the unified kernel image with the generated keys and computes TPM PCR measurements including secure boot variables (PCR7).

The nginx-kms example demonstrates this functionality with a complete secure boot setup, including key generation (with a --secure-boot flag). Note that the example generates keys at build time, making those builds non-reproducible; production use should provide pre-generated key material.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
