### PR TITLE
examples/nginx-kms: Lockdown kms-init service

### DIFF
--- a/nix/examples/nginx-kms/fcgi-script.nix
+++ b/nix/examples/nginx-kms/fcgi-script.nix
@@ -37,7 +37,7 @@ pkgs.writeScript "decrypt-wrapper.sh" ''
   fi
 
   # Read the symmetric key
-  SYMMETRIC_KEY=$(cat /run/symmetric_key | ${pkgs.coreutils}/bin/base64 -d | ${pkgs.xxd}/bin/xxd -p -c 32 | tr -d '\n')
+  SYMMETRIC_KEY=$(cat /run/kms-init/symmetric_key | ${pkgs.coreutils}/bin/base64 -d | ${pkgs.xxd}/bin/xxd -p -c 32 | tr -d '\n')
 
   # Extract IV (first 32 characters, as it's in hex format) and the rest is the actual ciphertext
   IV=''${CIPHERTEXT:0:32}

--- a/nix/examples/nginx-kms/flake.nix
+++ b/nix/examples/nginx-kms/flake.nix
@@ -11,11 +11,25 @@
         let
           pkgs = nixpkgs.legacyPackages."${system}";
           fcgiScript = pkgs.callPackage ./fcgi-script.nix { };
-          kmsInitScript = { key-group }: pkgs.callPackage ./kms-init.nix { inherit nitro-tee key-group; };
+          kmsInitScript = pkgs.callPackage ./kms-init.nix { inherit nitro-tee; };
           secureBootData = pkgs.callPackage ./secure-boot-data.nix { };
 
           # Common configuration shared between production and debug builds
           commonUserConfig = { config, pkgs, lib, ... }: {
+            users.groups.tpm = {};
+            users.groups.kms-init = {};
+
+            users.users.kms-init = {
+              isSystemUser = true;
+              group = "kms-init";
+              extraGroups = [ "tpm" ];
+            };
+            users.users.nginx.extraGroups = [ "kms-init" ];
+
+            services.udev.extraRules = ''
+              KERNEL=="tpm0", OWNER="root", GROUP="tpm", MODE="0660"
+            '';
+
             # systemd service for system initialization
             systemd.services.kms-init = {
               description = "Initialize KMS and decrypt symmetric key";
@@ -24,8 +38,45 @@
               after = [ "network-online.target" ];
               serviceConfig = {
                 Type = "oneshot";
-                ExecStart = kmsInitScript { key-group = config.services.nginx.group; };
+                ExecStart = kmsInitScript;
                 RemainAfterExit = true;
+
+                User = "kms-init";
+                RuntimeDirectory = "kms-init";
+                RuntimeDirectoryMode = "0750";
+                UMask = "0027";
+
+                ProtectSystem = "strict";
+                ProtectKernelTunables = true;
+                ProtectControlGroups = true;
+                ProtectClock = true;
+                ProtectKernelLogs = true;
+                ProtectKernelModules = true;
+                ProtectHome = true;
+                ProtectHostname = true;
+                ProtectProc = "invisible";
+                ProcSubset = "pid";
+
+                PrivateTmp = true;
+                PrivateUsers = true;
+
+                DevicePolicy = "closed";
+                DeviceAllow = [ "/dev/tpm0 rw" ];
+
+                RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+                RestrictRealtime = true;
+                RestrictSUIDSGID = true;
+                RestrictNamespaces = true;
+
+                NoNewPrivileges = true;
+                LockPersonality = true;
+                MemoryDenyWriteExecute = true;
+                RemoveIPC = true;
+
+                CapabilityBoundingSet = "";
+                SystemCallArchitectures = "native";
+                SystemCallFilter = [ "@system-service" "~@privileged" "~@resources"];
+                SystemCallErrorNumber = "EPERM";
               };
             };
 
@@ -65,8 +116,8 @@
               allowedTCPPorts = [ 80 ];
               # IMDS access control - specific to AWS KMS integration
               extraCommands = "
-                # Allow root (for kms-init service) to access IMDS for KMS operations
-                ${pkgs.iptables}/bin/iptables -A OUTPUT -d 169.254.169.254 -m owner --uid-owner root -j ACCEPT
+                # Allow kms-init service to access IMDS for KMS operations
+                ${pkgs.iptables}/bin/iptables -A OUTPUT -d 169.254.169.254 -m owner --uid-owner kms-init -j ACCEPT
                 # Allow nginx service to access IMDS for KMS operations
                 ${pkgs.iptables}/bin/iptables -A OUTPUT -d 169.254.169.254 -m owner --uid-owner nginx -j ACCEPT
                 # Block all other IMDS access for security

--- a/nix/examples/nginx-kms/kms-init.nix
+++ b/nix/examples/nginx-kms/kms-init.nix
@@ -2,7 +2,6 @@
   pkgs,
   system,
   nitro-tee,
-  key-group,
   ...
 }:
 pkgs.writeScript "kms-init.sh" ''
@@ -23,7 +22,5 @@ pkgs.writeScript "kms-init.sh" ''
   SYMMETRIC_KEY=$(${nitro-tee.packages.${system}.kms-decrypt-app}/bin/nitro-tpm-kms-decrypt --key-id "$KEY_ID" "$CIPHERTEXT")
 
   # Save the symmetric key to a known location
-  echo "$SYMMETRIC_KEY" > /run/symmetric_key
-  chmod 640 /run/symmetric_key
-  chown root:${key-group} /run/symmetric_key
+  echo "$SYMMETRIC_KEY" > /run/kms-init/symmetric_key
 ''


### PR DESCRIPTION
The kms-init service has been changed to run as a dedicated unprivileged user instead of root. The symmetric key is stored in a restricted runtime directory accessible only to the kms-init group, with nginx gaining access through group membership.

Comprehensive systemd sandboxing has been applied based on systemd's security analysis recommendations, including filesystem isolation, process visibility restrictions, capability dropping, and device access controls limited to the TPM device.

```
# systemd-analyze security kms-init.service --no-pager
  NAME                                                        DESCRIPTION                                                                    EXPOSURE
✓ SystemCallFilter=~@swap                                     System call allow list defined for service, and @swap is not included                  
✓ SystemCallFilter=~@resources                                System call allow list defined for service, and @resources is not included             
✓ SystemCallFilter=~@reboot                                   System call allow list defined for service, and @reboot is not included                
✓ SystemCallFilter=~@raw-io                                   System call allow list defined for service, and @raw-io is not included                
✓ SystemCallFilter=~@privileged                               System call allow list defined for service, and @privileged is not included            
✓ SystemCallFilter=~@obsolete                                 System call allow list defined for service, and @obsolete is not included              
✓ SystemCallFilter=~@mount                                    System call allow list defined for service, and @mount is not included                 
✓ SystemCallFilter=~@module                                   System call allow list defined for service, and @module is not included                
✓ SystemCallFilter=~@debug                                    System call allow list defined for service, and @debug is not included                 
✓ SystemCallFilter=~@cpu-emulation                            System call allow list defined for service, and @cpu-emulation is not included         
✓ SystemCallFilter=~@clock                                    System call allow list defined for service, and @clock is not included                 
✓ RemoveIPC=                                                  Service user cannot leave SysV IPC objects around                                      
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                       0.1
✓ User=/DynamicUser=                                          Service runs under a static non-root user identity                                     
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted                                       
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock                                       
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges                                        
✓ AmbientCapabilities=                                        Service process does not receive ambient capabilities                                  
✗ PrivateDevices=                                             Service potentially has access to hardware devices                                  0.2
✓ CapabilityBoundingSet=~CAP_BPF                              Service may not load BPF programs                                                      
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI                                  
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                               0.3
✓ ProtectSystem=                                              Service has strict read-only access to the OS file hierarchy                           
✓ ProtectProc=                                                Service has restricted access to process tree (/proc hidepid=)                         
✓ SupplementaryGroups=                                        Service has no supplementary groups                                                    
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access                                                          
✓ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has no ptrace() debugging abilities                                            
✓ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has no privileges to change resource use parameters                            
✓ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has no network configuration privileges                                        
✓ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has no elevated networking privileges                                          
✓ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has no audit subsystem access                                                  
✓ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has no administrator privileges                                                
✓ PrivateTmp=                                                 Service has no access to other software's temporary files                              
✓ ProcSubset=                                                 Service has no access to non-process /proc files (/proc subset=)                       
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging                                                
✓ ProtectHome=                                                Service has no access to home directories                                              
✗ PrivateNetwork=                                             Service has access to the host's network                                            0.5
✗ DeviceAllow=                                                Service has a device ACL with some special devices: char-rtc:r /dev/tpm0:rw         0.1
✓ KeyringMode=                                                Service doesn't share key material with other services                                 
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree                      
✓ PrivateUsers=                                               Service does not have access to other users                                            
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                    0.2
✓ NotifyAccess=                                               Service child processes cannot alter service state                                     
✓ ProtectClock=                                               Service cannot write to the hardware clock or system clock                             
✓ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service cannot use acct()                                                              
✓ CapabilityBoundingSet=~CAP_KILL                             Service cannot send UNIX signals to arbitrary processes                                
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer                        
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system                                  
✓ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service cannot override UNIX file/IPC permission checks                                
✓ ProtectControlGroups=                                       Service cannot modify the control group file system                                    
✓ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service cannot mark files immutable                                                    
✓ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service cannot lock memory into RAM                                                    
✓ ProtectKernelModules=                                       Service cannot load or read kernel modules                                             
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules                                                     
✓ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service cannot issue vhangup()                                                         
✓ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service cannot issue reboot()                                                          
✓ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service cannot issue chroot()                                                          
✓ PrivateMounts=                                              Service cannot install system mounts                                                   
✓ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service cannot establish wake locks                                                    
✓ MemoryDenyWriteExecute=                                     Service cannot create writable executable memory mappings                              
✓ RestrictNamespaces=~user                                    Service cannot create user namespaces                                                  
✓ RestrictNamespaces=~pid                                     Service cannot create process namespaces                                               
✓ RestrictNamespaces=~net                                     Service cannot create network namespaces                                               
✓ RestrictNamespaces=~uts                                     Service cannot create hostname namespaces                                              
✓ RestrictNamespaces=~mnt                                     Service cannot create file system namespaces                                           
✓ CapabilityBoundingSet=~CAP_LEASE                            Service cannot create file leases                                                      
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes                                                     
✓ RestrictNamespaces=~cgroup                                  Service cannot create cgroup namespaces                                                
✓ RestrictNamespaces=~ipc                                     Service cannot create IPC namespaces                                                   
✓ ProtectHostname=                                            Service cannot change system host/domainname                                           
✓ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service cannot change file ownership/access mode/capabilities                          
✓ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service cannot change UID/GID identities/capabilities                                  
✓ LockPersonality=                                            Service cannot change ABI personality                                                  
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)                                    
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets                                                 
✓ RestrictAddressFamilies=~AF_NETLINK                         Service cannot allocate netlink sockets                                                
✓ RestrictAddressFamilies=~AF_UNIX                            Service cannot allocate local sockets                                                  
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets                                                 
✓ CapabilityBoundingSet=~CAP_MAC_*                            Service cannot adjust SMACK MAC                                                        
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted                                       
✗ UMask=                                                      Files created by service are group-readable by default                              0.1

→ Overall exposure level for kms-init.service: 1.2 OK 🙂
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
