### PR TITLE
fix: set reproducible `mkfsOptions`

### DIFF
--- a/nix/image/verity.nix
+++ b/nix/image/verity.nix
@@ -37,6 +37,13 @@ in {
   };
 
   image.repart = {
+    mkfsOptions = {
+      # prevents non-reproducible images, where the builders FS allowed reflinks
+      # or not, which are used to construct the final nix store
+      squashfs = [ "-no-hardlinks" ];
+      erofs = [ "--hard-dereference" ];
+    };
+
     verityStore = {
       enable = true;
       # by default the module works with systemd-boot, for simplicity this test directly boots the UKI


### PR DESCRIPTION
When the image is built on host filesystems, which support reflinks, the images can differ compared to an image build where the fs does not support reflinks.

Dereferencing the hardlinks for the final image makes the image the same in both cases.
