### PR TITLE
Update NitroTPM tools to v1.1.0

### DIFF
--- a/nix/image/lib.nix
+++ b/nix/image/lib.nix
@@ -15,10 +15,10 @@ let
     pcr-compute = craneLib.buildPackage {
         cargoArtifacts = tee-pkgs.kms-decrypt-app.cargoArtifacts;
         pname = "nitro-tpm-pcr-compute";
-        version = "1.0.0";
+        version = "1.1.0";
         src = builtins.fetchGit {
             url = "https://github.com/aws/NitroTPM-Tools.git";
-            rev = "50f0fb58a306ee89c7994183cbce3bf4f3331207";
+            rev = "a37ff598acf32e3c8c2c85d53bb8f4025b0a12d7";
         };
         cargoExtraArgs = "--package nitro-tpm-pcr-compute";
         strictDeps = true;

--- a/nix/tee/packages.nix
+++ b/nix/tee/packages.nix
@@ -6,13 +6,13 @@
 let
     src = builtins.fetchGit {
         url = "https://github.com/aws/NitroTPM-Tools.git";
-        rev = "50f0fb58a306ee89c7994183cbce3bf4f3331207";
+        rev = "a37ff598acf32e3c8c2c85d53bb8f4025b0a12d7";
     };
 
     cargoArtifacts = craneLib.buildDepsOnly {
         inherit src;
         pname = "nitro-tpm-tools";
-        version = "1.0.0";
+        version = "1.1.0";
         strictDeps = true;
         doCheck = false;
 
@@ -28,7 +28,7 @@ in {
     kms-decrypt-app = craneLib.buildPackage {
         inherit cargoArtifacts src;
         pname = "kms-decrypt-app";
-        version = "1.0.0";
+        version = "1.0.1";
 
         cargoExtraArgs = "--example nitro-tpm-kms-decrypt";
         strictDeps = true;


### PR DESCRIPTION
In order to detect cmdline modifications, PCR12 is included in the KMS policy with a static zero value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
