### PR TITLE
refactor: separate secure boot signing from image build

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -81,16 +81,46 @@ Then the image can be built with:
 nix build .#raw-image
 ```
 
-We also provide additional tools to streamline the AMI creation process:
+The `tee-image` function produces an unsigned image with baseline TPM PCR4 measurements and an exported `unsigned.efi` UKI binary. Secure boot signing is an optional post-build step that keeps private keys out of the nix store.
+
+We also provide additional tools to streamline the AMI creation and signing process:
 
 * `create-ami`: A Nix Flake app for uploading the RAW image as an EC2 AMI. It uses the [EBS direct API](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-accessing-snapshot.html) to create an EBS snapshot and then generates a new AMI without launching an instance. Usage:
 ```bash
 nix run .#create-ami -- result/nixos-tee_1.raw
 ```
+* `sign-efi-image`: Signs an unsigned UKI binary with secure boot keys provided as file paths (not in the nix store). Use this after building to add secure boot signatures without exposing `db.key` in the nix cache. Usage:
+```bash
+nix run .#sign-efi-image -- result/unsigned.efi /path/to/db.key /path/to/db.crt
+```
+* `compute-pcrs`: Computes TPM PCR values for an EFI image. When secure boot ESL files are provided, PCR7 measurements are included alongside PCR4. Usage:
+```bash
+nix run .#compute-pcrs -- signed.efi --PK PK.esl --KEK KEK.esl --db db.esl -o tpm_pcr.json
+```
 * `boot-uefi-qemu`: A debugging tool that uses QEMU to load the RAW image with a software-emulated TPM. Note that this environment cannot start the full attestation flow. Usage:
 ```bash
 nix run .#boot-uefi-qemu -- result/nixos-tee_1.raw
 ```
+
+### Secure Boot Workflow
+
+For workloads requiring secure boot, the signing pipeline runs outside of nix:
+
+```bash
+# 1. Build unsigned image (produces result/unsigned.efi and result/tpm_pcr.json with PCR4)
+nix build .#raw-image
+
+# 2. Sign the UKI with your secure boot db key (in a secure environment)
+nix run .#sign-efi-image -- result/unsigned.efi /path/to/db.key /path/to/db.crt
+
+# 3. Compute full PCR values including PCR7 secure boot measurements
+nix run .#compute-pcrs -- signed.efi --PK PK.esl --KEK KEK.esl --db db.esl -o tpm_pcr.json
+
+# 4. Create AMI with UEFI secure boot variable store
+nix run .#create-ami-secure-boot -- result/nixos-tee_1.raw
+```
+
+This separation ensures private signing keys never enter the nix store or cache, while builds remain fully reproducible (same source always produces the same unsigned image and PCR4 values).
 
 ## Nix Web Server Example
 

--- a/nix/examples/nginx-kms/README.md
+++ b/nix/examples/nginx-kms/README.md
@@ -16,11 +16,15 @@ Before you begin, ensure you have the following:
 
 ## Important Note on Secure Boot and Reproducibility
 
-When using secure boot enabled builds (e.g., `raw-image-secure-boot`), the builds are **NOT reproducible** because this example generates cryptographic keys at build time. Each build will produce different keys and therefore different measurements for PCR7.
+Secure boot signing is a **post-build step** performed outside of the nix derivation. This keeps private signing keys (`db.key`) out of the nix store and cache.
 
-In production scenarios, you should use consistent key material across builds to maintain reproducible measurements.
+The build workflow is:
+1. `nix build .#raw-image` — produces an unsigned image and UKI
+2. `nix run .#sign-efi-image -- result/unsigned.efi /path/to/db.key /path/to/db.crt` — signs the UKI
+3. `nix run .#compute-pcrs -- signed.efi --PK PK.esl --KEK KEK.esl --db db.esl -o tpm_pcr.json` — computes PCR values including PCR7
+4. `nix run .#create-ami-secure-boot -- result/nixos-tee_1.raw` — registers AMI with UEFI secure boot data
 
-The non-secure-boot builds (`raw-image`) remain fully reproducible.
+In production, provide consistent pre-generated key material for reproducible measurements.
 
 ## Getting Started
 Follow these steps to set up and test the Attestable AMI:

--- a/nix/examples/nginx-kms/flake.nix
+++ b/nix/examples/nginx-kms/flake.nix
@@ -12,7 +12,7 @@
           pkgs = nixpkgs.legacyPackages."${system}";
           fcgiScript = pkgs.callPackage ./fcgi-script.nix { };
           kmsInitScript = pkgs.callPackage ./kms-init.nix { inherit nitro-tee; };
-          secureBootData = pkgs.callPackage ./secure-boot-data.nix { };
+          secureBootPublicData = pkgs.callPackage ./secure-boot-data.nix { };
 
           # Common configuration shared between production and debug builds
           commonUserConfig = { config, pkgs, lib, ... }: {
@@ -135,12 +135,6 @@
               isDebug = false;
             };
 
-            raw-image-secure-boot = nitro-tee.lib.${system}.tee-image {
-              userConfig = commonUserConfig;
-              isDebug = false;
-              secureBootData = secureBootData;
-            };
-
             # Debug build with console access enabled
             # WARNING: This enables operator access and bypasses security!
 
@@ -149,21 +143,19 @@
               isDebug = true;
             };
 
-            raw-image-secure-boot-debug = nitro-tee.lib.${system}.tee-image {
-              userConfig = commonUserConfig;
-              isDebug = true;
-              secureBootData = secureBootData;
-            };
+            # Secure boot key material (for use with sign-efi-image and create-ami-secure-boot)
+            secure-boot-keys = secureBootPublicData;
           };
 
-          # Expose the apps from nitro-tee
           apps = {
             boot-uefi-qemu = nitro-tee.apps.${system}.boot-uefi-qemu;
             create-ami = nitro-tee.apps.${system}.create-ami;
+            sign-efi-image = nitro-tee.apps.${system}.sign-efi-image;
+            compute-pcrs = nitro-tee.apps.${system}.compute-pcrs;
             create-ami-secure-boot = {
               type = "app";
               program = "${pkgs.writeShellScript "create-ami-secure-boot" ''
-                ${nitro-tee.apps.${system}.create-ami.program} "$1" "${secureBootData.uefiVarStore}/uefi_data.aws"
+                ${nitro-tee.apps.${system}.create-ami.program} "$1" "${secureBootPublicData.uefiVarStore}/uefi_data.aws"
               ''}";
             };
           };

--- a/nix/examples/nginx-kms/scripts/steps/00_create_ami.sh
+++ b/nix/examples/nginx-kms/scripts/steps/00_create_ami.sh
@@ -22,7 +22,6 @@ done
 
 # Build the package name based on flags
 PACKAGE_NAME="raw-image"
-[ "$SECURE_BOOT" = true ] && PACKAGE_NAME="${PACKAGE_NAME}-secure-boot"
 [ "$DEBUG" = true ] && PACKAGE_NAME="${PACKAGE_NAME}-debug"
 
 echo "Running Nix UKI build for package: $PACKAGE_NAME"
@@ -39,6 +38,35 @@ echo "Nix UKI build completed successfully."
 if [ ! -d "result" ]; then
   echo "Error: 'result' folder not found"
   exit 1
+fi
+
+# If secure boot, generate keys and sign the image
+if [ "$SECURE_BOOT" = true ]; then
+  echo "Building secure boot key material..."
+  nix --extra-experimental-features nix-command --extra-experimental-features flakes build .#secure-boot-keys --out-link sb-keys
+
+  if [ $? -ne 0 ]; then
+    echo "Error: Failed to build secure boot keys"
+    exit 1
+  fi
+
+  DB_KEY="sb-keys/db.key"
+  DB_CRT="sb-keys/db.crt"
+
+  if [ ! -f "$DB_KEY" ] || [ ! -f "$DB_CRT" ]; then
+    echo "Error: db.key or db.crt not found in secure-boot-keys output"
+    exit 1
+  fi
+
+  echo "Signing EFI image for secure boot..."
+  nix --extra-experimental-features nix-command --extra-experimental-features flakes run .#sign-efi-image -- \
+    result/unsigned.efi "$DB_KEY" "$DB_CRT" signed.efi
+
+  if [ $? -ne 0 ]; then
+    echo "Error: Secure boot signing failed"
+    exit 1
+  fi
+  echo "Image signed for secure boot."
 fi
 
 echo "Creating UKI AMI..."

--- a/nix/examples/nginx-kms/secure-boot-data.nix
+++ b/nix/examples/nginx-kms/secure-boot-data.nix
@@ -69,6 +69,7 @@ in
 pkgs.runCommand "secure-boot-data" {} ''
   mkdir -p $out
 
+  # Export both public and private key material for signing workflows
   cp ${secureBootKeys}/db.key ${secureBootKeys}/db.crt ${secureBootKeys}/*.esl $out/
 '' // {
   inherit uefiVarStore;

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -22,9 +22,9 @@
 
             lib = {
               # Lib function to build a raw TEE image
-              tee-image = { userConfig ? { }, isDebug ? false, secureBootData ? null } :
+              tee-image = { userConfig ? { }, isDebug ? false } :
                 pkgs.callPackage ./image/lib.nix {
-                  inherit nixos-generators userConfig isDebug secureBootData;
+                  inherit nixos-generators userConfig isDebug;
                   tee-pkgs = packages;
                 };
             };
@@ -35,6 +35,10 @@
               boot-uefi-qemu = pkgs.callPackage ./utils/boot-uefi-qemu.nix { };
               # Create an AMI from the raw image input
               create-ami = pkgs.callPackage ./utils/create-ami.nix { };
+              # Sign an unsigned EFI binary with secure boot keys
+              sign-efi-image = pkgs.callPackage ./utils/sign-efi-image.nix { };
+              # Compute TPM PCR values from an EFI image
+              compute-pcrs = pkgs.callPackage ./utils/compute-pcrs.nix { };
             };
           }
       );

--- a/nix/image/lib.nix
+++ b/nix/image/lib.nix
@@ -6,36 +6,9 @@
   tee-pkgs,
   userConfig ? { },
   isDebug ? false,
-  secureBootData ? null,
   ...
 }:
 let
-
-    # Sign EFI binary with secure boot keys if secureBootData is provided
-    sign-efi = efiPath:
-        if secureBootData != null then
-            pkgs.runCommand "signed-efi" {
-                nativeBuildInputs = [ pkgs.sbsigntool ];
-            } ''
-                mkdir -p $out
-
-                # Verify required secure boot files exist
-                if [ ! -f "${secureBootData}/db.key" ]; then
-                    echo "ERROR: Secure boot signing key not found: ${secureBootData}/db.key"
-                    exit 1
-                fi
-                if [ ! -f "${secureBootData}/db.crt" ]; then
-                    echo "ERROR: Secure boot certificate not found: ${secureBootData}/db.crt"
-                    exit 1
-                fi
-
-                # Sign the EFI binary using the signature database (db) key
-                sbsign --key ${secureBootData}/db.key \
-                       --cert ${secureBootData}/db.crt \
-                       --output $out/signed.efi \
-                       ${efiPath}
-            ''
-        else null;
 
     tee-config = {
         environment = {
@@ -74,31 +47,13 @@ let
     }).overrideAttrs
         (oldAttrs: let
             originalEfiPath = oldAttrs.finalPartitions."00-esp".contents."${ukiPath}".source;
-            signedEfiDrv = sign-efi originalEfiPath;
-            finalEfiPath = if signedEfiDrv != null then "${signedEfiDrv}/signed.efi" else originalEfiPath;
         in {
-            finalPartitions = lib.recursiveUpdate oldAttrs.finalPartitions {
-                "00-esp".contents = {
-                    "${ukiPath}".source = finalEfiPath;
-                };
-            };
+            postInstall = ''
+                # Compute baseline TPM PCR values (PCR4 UKI measurement)
+                ${pkgs.nitrotpm-tools}/bin/nitro-tpm-pcr-compute --image ${originalEfiPath} > $out/tpm_pcr.json
 
-            postInstall = let
-                # Build secure boot arguments for PCR7 computation
-                secureBootArgs = lib.optionals (secureBootData != null) (
-                    lib.optional (builtins.pathExists "${secureBootData}/PK.esl") "--PK ${secureBootData}/PK.esl" ++
-                    lib.optional (builtins.pathExists "${secureBootData}/KEK.esl") "--KEK ${secureBootData}/KEK.esl" ++
-                    lib.optional (builtins.pathExists "${secureBootData}/db.esl") "--db ${secureBootData}/db.esl" ++
-                    lib.optional (builtins.pathExists "${secureBootData}/dbx.esl") "--dbx ${secureBootData}/dbx.esl"
-                );
-            in ''
-                # Compute TPM PCR values including secure boot measurements
-                ${pkgs.nitrotpm-tools}/bin/nitro-tpm-pcr-compute --image ${finalEfiPath} ${lib.concatStringsSep " " secureBootArgs} > $out/tpm_pcr.json
-
-                ${lib.optionalString (secureBootData != null) ''
-                    # Verify the EFI binary signature for secure boot compliance
-                    ${pkgs.sbsigntool}/bin/sbverify --cert ${secureBootData}/db.crt "${finalEfiPath}"
-                ''}
+                # Export the unsigned UKI for downstream signing
+                cp ${originalEfiPath} $out/unsigned.efi
             '';
         });
 in pkgs.stdenv.mkDerivation {

--- a/nix/utils/compute-pcrs.nix
+++ b/nix/utils/compute-pcrs.nix
@@ -1,0 +1,71 @@
+{ pkgs, lib, stdenv, system }:
+
+let
+  script = pkgs.writeShellApplication {
+    name = "compute-pcrs";
+    runtimeInputs = with pkgs; [
+      nitrotpm-tools
+    ];
+
+    text = ''
+      if [ "$#" -lt 1 ]; then
+        echo "Usage: compute-pcrs <efi-image> [--PK <PK.esl>] [--KEK <KEK.esl>] [--db <db.esl>] [--dbx <dbx.esl>] [-o <output.json>]"
+        echo ""
+        echo "Computes TPM PCR values for the given EFI image."
+        echo "When secure boot ESL files are provided, PCR7 measurements are included."
+        echo ""
+        echo "Arguments:"
+        echo "  efi-image     Path to the EFI binary (signed or unsigned)"
+        echo "  --PK          Path to Platform Key EFI Signature List"
+        echo "  --KEK         Path to Key Exchange Key EFI Signature List"
+        echo "  --db          Path to Signature Database EFI Signature List"
+        echo "  --dbx         Path to Forbidden Signatures EFI Signature List"
+        echo "  -o            Output file path (default: stdout)"
+        exit 1
+      fi
+
+      EFI_IMAGE="$1"
+      shift
+
+      if [ ! -f "$EFI_IMAGE" ]; then
+        echo "Error: EFI image '$EFI_IMAGE' not found" >&2
+        exit 1
+      fi
+
+      OUTPUT=""
+      PCR_ARGS=()
+
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --PK|--KEK|--db|--dbx)
+            if [ -z "''${2:-}" ] || [ ! -f "''${2:-}" ]; then
+              echo "Error: File for $1 not found: ''${2:-}" >&2
+              exit 1
+            fi
+            PCR_ARGS+=("$1" "$2")
+            shift 2
+            ;;
+          -o)
+            OUTPUT="''${2:-}"
+            shift 2
+            ;;
+          *)
+            echo "Error: Unknown argument: $1" >&2
+            exit 1
+            ;;
+        esac
+      done
+
+      if [ -n "$OUTPUT" ]; then
+        nitro-tpm-pcr-compute --image "$EFI_IMAGE" "''${PCR_ARGS[@]}" > "$OUTPUT"
+        echo "PCR values written to: $OUTPUT" >&2
+      else
+        nitro-tpm-pcr-compute --image "$EFI_IMAGE" "''${PCR_ARGS[@]}"
+      fi
+    '';
+  };
+in
+{
+  type = "app";
+  program = "${script}/bin/compute-pcrs";
+}

--- a/nix/utils/sign-efi-image.nix
+++ b/nix/utils/sign-efi-image.nix
@@ -1,0 +1,61 @@
+{ pkgs, lib, stdenv, system }:
+
+let
+  script = pkgs.writeShellApplication {
+    name = "sign-efi-image";
+    runtimeInputs = with pkgs; [
+      sbsigntool
+    ];
+
+    text = ''
+      if [ "$#" -lt 3 ]; then
+        echo "Usage: sign-efi-image <unsigned-efi> <db.key> <db.crt> [output-path]"
+        echo ""
+        echo "Signs an EFI binary with the provided secure boot db key and certificate."
+        echo "The key and certificate must be provided as file paths (NOT in the nix store)."
+        echo ""
+        echo "Arguments:"
+        echo "  unsigned-efi  Path to the unsigned EFI binary (e.g. result/unsigned.efi)"
+        echo "  db.key        Path to the secure boot signing private key"
+        echo "  db.crt        Path to the secure boot signing certificate"
+        echo "  output-path   Optional output path (default: signed.efi in current directory)"
+        exit 1
+      fi
+
+      UNSIGNED_EFI="$1"
+      DB_KEY="$2"
+      DB_CRT="$3"
+      OUTPUT="''${4:-./signed.efi}"
+
+      if [ ! -f "$UNSIGNED_EFI" ]; then
+        echo "Error: Unsigned EFI file '$UNSIGNED_EFI' not found"
+        exit 1
+      fi
+
+      if [ ! -f "$DB_KEY" ]; then
+        echo "Error: Signing key '$DB_KEY' not found"
+        exit 1
+      fi
+
+      if [ ! -f "$DB_CRT" ]; then
+        echo "Error: Signing certificate '$DB_CRT' not found"
+        exit 1
+      fi
+
+      echo "Signing EFI binary..."
+      sbsign --key "$DB_KEY" \
+             --cert "$DB_CRT" \
+             --output "$OUTPUT" \
+             "$UNSIGNED_EFI"
+
+      echo "Verifying signature..."
+      sbverify --cert "$DB_CRT" "$OUTPUT"
+
+      echo "Done. Signed EFI written to: $OUTPUT"
+    '';
+  };
+in
+{
+  type = "app";
+  program = "${script}/bin/sign-efi-image";
+}


### PR DESCRIPTION
Decouple EFI signing from the nix image builder so private keys (db.key) never enter the nix store. The build pipeline is now three stages: build unsigned image → sign externally → compute PCRs.

Key changes:
- Remove secureBootData parameter and sign-efi from nix/image/lib.nix; image builder now outputs unsigned.efi only
- Stop exporting db.key from secure-boot-data derivation (public material and UEFI var store only)
- Add standalone sign-efi-image and compute-pcrs flake apps for use in CI/CD where keys are injected at runtime
- Expose both utilities from the main flake and remove secureBootData from the tee-image interface
- Refactor nginx-kms example to use post-build signing
- Update READMEs documenting the new workflow

Addresses: https://github.com/aws/nitrotpm-attestation-samples/issues/15
