### PR TITLE
ci: add GitHub Actions workflow for nix lint and build

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,10 @@
+name: Setup Nix
+description: Install pinned Nix with flakes enabled
+runs:
+  using: composite
+  steps:
+    - uses: cachix/install-nix-action@v27
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.18.9/install
+        extra_nix_config: |
+          experimental-features = nix-command flakes

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,61 @@
+name: Nix CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.18.9/install
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      # Eval concrete attrs instead of `nix flake check`, which rejects the
+      # callPackage-injected override/overrideDerivation attrs as non-derivations.
+      - name: Evaluate root flake packages
+        run: |
+          nix eval ./nix#packages.x86_64-linux.kms-decrypt-app.drvPath --no-write-lock-file
+      - name: Evaluate root flake apps
+        run: |
+          for app in boot-uefi-qemu compute-pcrs create-ami generate-uefi-vars sign-efi-image; do
+            echo "== apps.$app =="
+            nix eval "./nix#apps.x86_64-linux.$app.program" --no-write-lock-file
+          done
+      - name: Evaluate nginx-kms packages
+        run: |
+          for pkg in raw-image raw-image-debug; do
+            echo "== packages.$pkg =="
+            nix eval "./nix/examples/nginx-kms#packages.x86_64-linux.$pkg.drvPath" --no-write-lock-file
+          done
+      # statix/deadnix report-only (non-gating).
+      - name: Lint with statix (report-only)
+        run: nix run nixpkgs#statix -- check nix/ || true
+      - name: Lint with deadnix (report-only)
+        run: nix run nixpkgs#deadnix -- nix/
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - ./nix#kms-decrypt-app
+          - ./nix/examples/nginx-kms#raw-image
+          - ./nix/examples/nginx-kms#raw-image-debug
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.18.9/install
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Build ${{ matrix.target }}
+        run: nix build '${{ matrix.target }}' --no-write-lock-file

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,39 +6,30 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          install_url: https://releases.nixos.org/nix/nix-2.18.9/install
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: ./.github/actions/setup-nix
       # Eval concrete attrs instead of `nix flake check`, which rejects the
       # callPackage-injected override/overrideDerivation attrs as non-derivations.
-      - name: Evaluate root flake packages
-        run: |
-          nix eval ./nix#packages.x86_64-linux.kms-decrypt-app.drvPath --no-write-lock-file
+      # Package targets are already evaluated by the build job; the apps are
+      # never built in CI, so this is their only check.
       - name: Evaluate root flake apps
         run: |
-          for app in boot-uefi-qemu compute-pcrs create-ami generate-uefi-vars sign-efi-image; do
+          for app in $(nix eval "./nix#apps.x86_64-linux" --apply builtins.attrNames --json --no-write-lock-file | jq -r '.[]'); do
             echo "== apps.$app =="
             nix eval "./nix#apps.x86_64-linux.$app.program" --no-write-lock-file
-          done
-      - name: Evaluate nginx-kms packages
-        run: |
-          for pkg in raw-image raw-image-debug; do
-            echo "== packages.$pkg =="
-            nix eval "./nix/examples/nginx-kms#packages.x86_64-linux.$pkg.drvPath" --no-write-lock-file
           done
       # statix/deadnix report-only (non-gating).
       - name: Lint with statix (report-only)
         run: nix run nixpkgs#statix -- check nix/ || true
       - name: Lint with deadnix (report-only)
-        run: nix run nixpkgs#deadnix -- nix/
+        run: nix run nixpkgs#deadnix -- nix/ || true
 
   build:
     runs-on: ubuntu-latest
@@ -51,11 +42,6 @@ jobs:
           - ./nix/examples/nginx-kms#raw-image-debug
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          install_url: https://releases.nixos.org/nix/nix-2.18.9/install
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: ./.github/actions/setup-nix
       - name: Build ${{ matrix.target }}
         run: nix build '${{ matrix.target }}' --no-write-lock-file


### PR DESCRIPTION
Lint job evaluates concrete outputs of both flakes (package drvPaths and app programs), avoiding `nix flake check` which rejects the callPackage-injected override/overrideDerivation attrs. statix and deadnix run report-only (non-gating).

Build job matrix-builds all package targets: kms-decrypt-app plus the nginx-kms raw-image and raw-image-debug. Pins Nix 2.18.9.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
