### PR TITLE
ci: fix example flake builds by overriding mutable path input

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -5,6 +5,6 @@ runs:
   steps:
     - uses: cachix/install-nix-action@v27
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.18.9/install
+        install_url: https://releases.nixos.org/nix/nix-2.28.3/install
         extra_nix_config: |
           experimental-features = nix-command flakes

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -3,6 +3,12 @@ description: Install pinned Nix with flakes enabled
 runs:
   using: composite
   steps:
+    # Ubuntu 24.04 runners restrict unprivileged user namespaces via AppArmor,
+    # which breaks systemd-repart's `unshare --map-root-user` inside the nix
+    # build sandbox (uid_map write fails with EPERM).
+    - name: Allow unprivileged user namespaces
+      shell: bash
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - uses: cachix/install-nix-action@v27
       with:
         install_url: https://releases.nixos.org/nix/nix-2.28.3/install


### PR DESCRIPTION
The nginx-kms example builds failed in CI for two runner-environment reasons:

* Bump pinned Nix 2.18.9 → 2.28.3: The example flakes use a relative path input
(path:../..), whose lock format was introduced in Nix 2.26. The older pinned Nix
rejects it with error: lock file contains mutable lock.

* Allow unprivileged user namespaces: `systemd-repart` builds the image under unshare
`--map-root-user`, which Ubuntu 24.04 runners block via AppArmor (`unshare: write failed
/proc/self/uid_map: Operation not permitted`). The setup-nix action now disables the
restriction via `sysctl`; this only affects the ephemeral runner VM.

