### PR TITLE
fix(nginx-kms): deny admin kms:Decrypt to enforce attestation gating

### DIFF
--- a/nix/examples/nginx-kms/scripts/steps/02_create_kms_key.sh
+++ b/nix/examples/nginx-kms/scripts/steps/02_create_kms_key.sh
@@ -148,6 +148,18 @@ KEY_POLICY=$(cat <<EOF
       "Resource": "*"
     },
     {
+      "Sid": "Deny admin decrypt without attestation",
+      "Effect": "Deny",
+      "Principal": {
+        "AWS": "${ADMIN_ROLE}"
+      },
+      "Action": [
+        "kms:Decrypt",
+        "kms:ReEncryptFrom"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "Allow decryption for the Instance role",
       "Effect": "Allow",
       "Principal": {


### PR DESCRIPTION
Add an explicit Deny for kms:Decrypt and kms:ReEncryptFrom on the admin principal so only attested instances can decrypt.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
